### PR TITLE
feat: 백업용 R2버킷 및 오탐수집용 R2버킷 생성 및 생명주기 추가

### DIFF
--- a/cloud-backup/blackbox_bucket.tf
+++ b/cloud-backup/blackbox_bucket.tf
@@ -1,0 +1,28 @@
+// 블랙박스 R2 버킷 선언
+resource "cloudflare_r2_bucket" "blackbox_r2_bucket" {
+  account_id    = var.account_id
+  name          = var.blackbox_bucket_name // 주의: 버킷 실제 이름은 kebab-case를 지켜야 함
+  storage_class = "Standard"
+}
+
+// 블랙박스 버킷 생명주기 설정
+resource "cloudflare_r2_bucket_lifecycle" "blackbox_r2_bucket_lifecycle" {
+  account_id  = var.account_id
+  bucket_name = var.blackbox_bucket_name
+  rules = [{
+    id      = "Make sure to move objects older than 30 days to infrequent-access storageclass"
+    enabled = true
+    conditions = {
+      prefix = "" // 모든 객체에 대해서
+    }
+    storage_class_transitions = [{
+      condition = {
+        max_age = 60 * 60 * 24 * 30 // 초 단위, 즉 30일 이후
+        type    = "Age"
+      }
+      storage_class = "InfrequentAccess"
+    }]
+  }]
+
+}
+

--- a/cloud-backup/fp_bucket.tf
+++ b/cloud-backup/fp_bucket.tf
@@ -1,0 +1,27 @@
+// 오탐데이터 R2 버킷 선언
+resource "cloudflare_r2_bucket" "fp_r2_bucket" {
+  account_id    = var.account_id
+  name          = var.fp_bucket_name // 주의: 버킷 실제 이름은 kebab-case를 지켜야 함
+  storage_class = "Standard"
+}
+
+// 오탐데이터 버킷 생명주기 설정
+resource "cloudflare_r2_bucket_lifecycle" "fp_r2_bucket_lifecycle" {
+  account_id  = var.account_id
+  bucket_name = var.fp_bucket_name
+  rules = [{
+    id      = "Expire All fp objects older than 100days"
+    enabled = true
+    conditions = {
+      prefix = "" // 모든 객체에 대해서
+    }
+    delete_objects_transition = {
+      condition = {
+        max_age = 60 * 60 * 24 * 100 // 초 단위, 즉 100일 이후 삭제
+        type    = "Age"
+      }
+    }
+  }]
+
+}
+

--- a/cloud-backup/main.tf
+++ b/cloud-backup/main.tf
@@ -16,9 +16,3 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
-// R2 버킷 선언
-resource "cloudflare_r2_bucket" "blackbox_r2_bucket" {
-  account_id    = var.account_id
-  name          = var.bucket_name // 주의: 이름은 kebab-case를 지켜야 함
-  storage_class = "Standard"
-}

--- a/cloud-backup/variables.tf
+++ b/cloud-backup/variables.tf
@@ -6,6 +6,10 @@ variable "account_id" {
   type = string
 }
 
-variable "bucket_name" {
-    type = string
+variable "blackbox_bucket_name" {
+  type = string
+}
+
+variable "fp_bucket_name" {
+  type = string
 }


### PR DESCRIPTION
R2버킷 생성:
- 사고현장 백업용 -> 첫 30일 Standard -> 이후 IA(비용절감)
- 오탐데이터 저장용 -> 100일이후 삭제

@treeshine 
@Lilpha 

Resolves #30 