### PR TITLE
fix: FCM 푸시 알림 전송 실패하더라도 abort되지 않도록

### DIFF
--- a/backup-server/src/services/fcm_service.py
+++ b/backup-server/src/services/fcm_service.py
@@ -36,4 +36,4 @@ class FCMService:
                 logger.info(f"response from FCM: {response}")
 
         except Exception as e:
-            raise e
+            logger.warning(f"푸시 알림 보내기 실패: {e}")


### PR DESCRIPTION
FCM 푸시 알림을 전송하는데 실패하더라도 나머지 클라이언트들에게 전파되도록 설정